### PR TITLE
Handle all HTTP posting in the worker

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ be backwards compatible.
 Add the following to your `config/environments/production.rb`:
 
 ```ruby
-Rails.application.configure do
+Rails.application.configure do |config|
   # ...
   config.opbeat.organization_id = 'XXX'
   config.opbeat.app_id = 'XXX'

--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
-# ![Opbeat](http://s3.brnbw.com/opbeat_logo.png)
+<h1>
+  <img src='http://opbeat-brand-assets.s3-website-us-east-1.amazonaws.com/svg/logo/logo.svg' width=80% alt='Opbeat' />
+</h1>
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <h1>
-  <img src='http://opbeat-brand-assets.s3-website-us-east-1.amazonaws.com/svg/logo/logo.svg' width=80% alt='Opbeat' />
+
 </h1>
 
 ## Installation

--- a/lib/opbeat.rb
+++ b/lib/opbeat.rb
@@ -21,6 +21,8 @@ module Opbeat
   #
   # @param conf [Configuration] An Configuration object
   def self.start! conf
+    conf.validate!
+
     Client.start! conf
   end
 

--- a/lib/opbeat.rb
+++ b/lib/opbeat.rb
@@ -66,6 +66,12 @@ module Opbeat
     client.report exception, opts
   end
 
+  # Captures any exceptions raised inside the block
+  #
+  def self.capture &block
+    client.capture(&block)
+  end
+
   # Notify Opbeat of a release
   #
   # @param rel [Hash]

--- a/lib/opbeat.rb
+++ b/lib/opbeat.rb
@@ -21,8 +21,6 @@ module Opbeat
   #
   # @param conf [Configuration] An Configuration object
   def self.start! conf
-    conf.validate!
-
     Client.start! conf
   end
 

--- a/lib/opbeat.rb
+++ b/lib/opbeat.rb
@@ -78,8 +78,8 @@ module Opbeat
   # @option rel [String] :rev Revision
   # @option rel [String] :branch
   # @return [Net::HTTPResponse]
-  def self.release rel
-    client.release rel
+  def self.release rel, opts = {}
+    client.release rel, opts
   end
 
   private

--- a/lib/opbeat/client.rb
+++ b/lib/opbeat/client.rb
@@ -145,12 +145,12 @@ module Opbeat
       enqueue Worker::PostRequest.new('/errors/', data)
     end
 
-    def capture
+    def capture &block
       unless block_given?
         return Kernel.at_exit do
           if $!
-            logger.debug "Caught a post-mortem exception: #{$!.inspect}"
-            report($!)
+            debug $!.inspect
+            report $!
           end
         end
       end
@@ -160,7 +160,7 @@ module Opbeat
       rescue Error => e
         raise # Don't capture Opbeat errors
       rescue Exception => e
-        report(e)
+        report e
         raise
       end
     end

--- a/lib/opbeat/client.rb
+++ b/lib/opbeat/client.rb
@@ -121,7 +121,7 @@ module Opbeat
       ensure_worker_running
 
       if config.environment == 'development'
-        debug { Util::Inspector.new.transaction transaction }
+        debug { Util::Inspector.new.transaction transaction, include_parents: true }
       end
 
       @pending_transactions << transaction

--- a/lib/opbeat/client.rb
+++ b/lib/opbeat/client.rb
@@ -148,6 +148,8 @@ module Opbeat
     # errors
 
     def report exception, opts = {}
+      return if config.disable_errors
+
       return unless exception
 
       unless exception.backtrace

--- a/lib/opbeat/client.rb
+++ b/lib/opbeat/client.rb
@@ -120,6 +120,10 @@ module Opbeat
     def submit_transaction transaction
       ensure_worker_running
 
+      if config.environment == 'development'
+        debug { Util::Inspector.new.transaction transaction }
+      end
+
       @pending_transactions << transaction
 
       if should_send_transactions?

--- a/lib/opbeat/configuration.rb
+++ b/lib/opbeat/configuration.rb
@@ -15,7 +15,10 @@ module Opbeat
       use_ssl: true,
       current_user_method: :current_user,
       environment: ENV['RACK_ENV'] || ENV['RAILS_ENV'] || 'default',
-      transaction_post_interval: 60
+      transaction_post_interval: 60,
+
+      disable_performance: false,
+      disable_errors: false
     }.freeze
 
     attr_accessor :secret_token
@@ -35,6 +38,9 @@ module Opbeat
     attr_accessor :current_user_method
     attr_accessor :environment
     attr_accessor :transaction_post_interval
+
+    attr_accessor :disable_performance
+    attr_accessor :disable_errors
 
     attr_accessor :view_paths
 

--- a/lib/opbeat/configuration.rb
+++ b/lib/opbeat/configuration.rb
@@ -48,8 +48,12 @@ module Opbeat
       end
     end
 
-    def validate
-      # TODO
+    def validate!
+      %w{app_id secret_token organization_id}.each do |key|
+        raise Error.new("Configuration missing `#{key}'") unless self.send(key)
+      end
+
+      true
     end
   end
 end

--- a/lib/opbeat/error_message/stacktrace.rb
+++ b/lib/opbeat/error_message/stacktrace.rb
@@ -46,6 +46,7 @@ module Opbeat
 
           def strip_load_path path
             prefix = $:
+              .map(&:to_s)
               .select { |s| path.start_with?(s) }
               .sort_by { |s| s.length }
               .last

--- a/lib/opbeat/integration/rails/inject_exceptions_catcher.rb
+++ b/lib/opbeat/integration/rails/inject_exceptions_catcher.rb
@@ -8,9 +8,7 @@ module Opbeat
 
         def render_exception_with_opbeat(env, exception)
           begin
-            if Opbeat.started?
-              Opbeat.report(exception, rack_env: env)
-            end
+            Opbeat.report(exception, rack_env: env) if Opbeat.started?
           rescue
             ::Rails::logger.debug "** [Opbeat] Error capturing or sending exception #{$!}"
           end

--- a/lib/opbeat/integration/rails/inject_exceptions_catcher.rb
+++ b/lib/opbeat/integration/rails/inject_exceptions_catcher.rb
@@ -10,7 +10,8 @@ module Opbeat
           begin
             Opbeat.report(exception, rack_env: env) if Opbeat.started?
           rescue
-            ::Rails::logger.debug "** [Opbeat] Error capturing or sending exception #{$!}"
+            ::Rails::logger.error "** [Opbeat] Error capturing or sending exception #{$!}"
+            ::Rails::logger.debug $!.backtrace.join("\n")
           end
 
           render_exception_without_opbeat(env, exception)

--- a/lib/opbeat/integration/railtie.rb
+++ b/lib/opbeat/integration/railtie.rb
@@ -5,7 +5,8 @@ module Opbeat
   class Railtie < Rails::Railtie
 
     config.opbeat = ActiveSupport::OrderedOptions.new
-    config.opbeat.enabled_environments = Configuration::DEFAULTS[:enabled_environments]
+    # bootstrap options with the defaults
+    Configuration::DEFAULTS.each { |k,v| config.opbeat[k] = v }
 
     initializer "opbeat.configure" do |app|
       config = Configuration.new app.config.opbeat do |conf|
@@ -33,11 +34,9 @@ module Opbeat
       end
     end
 
-    # :nocov:
     rake_tasks do
       require 'opbeat/tasks'
     end
-    # :nocov:
 
   end
 end

--- a/lib/opbeat/middleware.rb
+++ b/lib/opbeat/middleware.rb
@@ -7,8 +7,12 @@ module Opbeat
     def call env
       begin
         transaction = Opbeat.transaction "Rack", "app.rack.request"
+
         resp = @app.call env
-        transaction.submit(resp.first)
+
+        if transaction
+          resp[2] = BodyProxy.new(resp[2]) { transaction.submit(resp[0]) }
+        end
       rescue Error
         raise # Don't report Opbeat errors
       rescue Exception => e
@@ -24,6 +28,36 @@ module Opbeat
       end
 
       resp
+    end
+  end
+
+  class BodyProxy
+    def initialize body, &block
+      @body, @block, @closed = body, block, false
+    end
+
+    def close
+      return if closed?
+
+      @closed = true
+
+      begin
+        @body.close if @body.respond_to?(:close)
+      ensure
+        @block.call
+      end
+    end
+
+    def closed?
+      @closed
+    end
+
+    def respond_to? method
+      @body.respond_to? method
+    end
+
+    def method_missing method, *args, &block
+      @body.send(method, *args, &block)
     end
   end
 end

--- a/lib/opbeat/middleware.rb
+++ b/lib/opbeat/middleware.rb
@@ -36,6 +36,10 @@ module Opbeat
       @body, @block, @closed = body, block, false
     end
 
+    def respond_to? *args
+      super || @body.respond_to?(*args)
+    end
+
     def close
       return if closed?
 
@@ -52,12 +56,8 @@ module Opbeat
       @closed
     end
 
-    def respond_to? method
-      @body.respond_to? method
-    end
-
-    def method_missing method, *args, &block
-      @body.send(method, *args, &block)
+    def method_missing *args, &block
+      @body.__send__(*args, &block)
     end
   end
 end

--- a/lib/opbeat/subscriber.rb
+++ b/lib/opbeat/subscriber.rb
@@ -68,7 +68,13 @@ module Opbeat
     private
 
     def parents_for transaction
-      transaction.notifications.select(&:trace).map { |n| n.trace.signature }
+      traces = transaction.notifications.select(&:trace)
+
+      if traces.any?
+        traces.map { |n| n.trace.signature }
+      else
+        [transaction.root_trace.signature]
+      end
     end
 
     def actions_regex

--- a/lib/opbeat/tasks.rb
+++ b/lib/opbeat/tasks.rb
@@ -13,7 +13,11 @@ namespace :opbeat do
     # log to STDOUT
     Opbeat::Client.inst.config.logger = Logger.new STDOUT
 
-    unless Opbeat.release(rev: rev, branch: ENV['BRANCH'], status: 'completed', inline: true)
+    unless Opbeat.release({
+        rev: rev,
+        branch: ENV['BRANCH'],
+        status: 'completed'
+    }, inline: true)
       exit 1 # release returned nil
     end
   end

--- a/lib/opbeat/tasks.rb
+++ b/lib/opbeat/tasks.rb
@@ -13,7 +13,7 @@ namespace :opbeat do
     # log to STDOUT
     Opbeat::Client.inst.config.logger = Logger.new STDOUT
 
-    unless Opbeat.release(rev: rev, branch: ENV['BRANCH'], status: 'completed')
+    unless Opbeat.release(rev: rev, branch: ENV['BRANCH'], status: 'completed', inline: true)
       exit 1 # release returned nil
     end
   end

--- a/lib/opbeat/trace.rb
+++ b/lib/opbeat/trace.rb
@@ -3,7 +3,7 @@ require 'opbeat/util'
 module Opbeat
   class Trace
 
-    def initialize transaction, signature, kind = 'code.custom'.freeze, parents = nil, extra = {}
+    def initialize transaction, signature, kind = 'code.custom', parents = nil, extra = {}
       @transaction = transaction
       @signature = signature
       @kind = kind
@@ -30,7 +30,7 @@ module Opbeat
     end
 
     def done
-      @duration = ((Time.now.to_f - @start_time) * 1000).round 4
+      @duration = ((Time.now.to_f - @start_time) * 1000)
 
       self
     end

--- a/lib/opbeat/transaction.rb
+++ b/lib/opbeat/transaction.rb
@@ -3,10 +3,7 @@ require 'opbeat/util'
 module Opbeat
   class Transaction
 
-    DEFAULT_KIND = 'code.custom'.freeze
-    DEFAULT_ROOT_SIGNATURE = 'transaction'.freeze
-
-    def initialize client, endpoint, kind = DEFAULT_KIND, result = nil
+    def initialize client, endpoint, kind = 'code.custom', result = nil
       @client = client
       @endpoint = endpoint
       @kind = kind
@@ -15,7 +12,7 @@ module Opbeat
       @timestamp = Util.nearest_minute.to_i
       @start = Time.now.to_f
 
-      @root = Trace.new(self, endpoint, DEFAULT_ROOT_SIGNATURE, nil).start(@start)
+      @root = Trace.new(self, endpoint, 'transaction', nil).start(@start)
       @traces = [@root]
       @notifications = []
     end

--- a/lib/opbeat/transaction.rb
+++ b/lib/opbeat/transaction.rb
@@ -49,7 +49,7 @@ module Opbeat
 
       release
 
-      @client.enqueue self
+      @client.submit_transaction self
     end
 
     def trace signature, kind = nil, parents = nil, extra = {}, &block

--- a/lib/opbeat/transaction.rb
+++ b/lib/opbeat/transaction.rb
@@ -12,16 +12,16 @@ module Opbeat
       @timestamp = Util.nearest_minute.to_i
       @start = Time.now.to_f
 
-      @root = Trace.new(self, endpoint, 'transaction', nil).start(@start)
-      @traces = [@root]
+      @root_trace = Trace.new(self, endpoint, 'transaction', nil).start(@start)
+      @traces = [@root_trace]
       @notifications = []
     end
 
     attr_accessor :endpoint, :kind, :result, :duration
-    attr_reader :timestamp, :start, :traces, :notifications
+    attr_reader :timestamp, :start, :traces, :notifications, :root_trace
 
     def endpoint= val
-      @endpoint = @root.signature = val
+      @endpoint = @root_trace.signature = val
     end
 
     def release
@@ -31,14 +31,14 @@ module Opbeat
     def done result = nil
       @result = result
 
-      @root.done
-      @duration = @root.duration
+      @root_trace.done
+      @duration = @root_trace.duration
 
       self
     end
 
     def done?
-      @root.done?
+      @root_trace.done?
     end
 
     def submit result = nil
@@ -50,7 +50,7 @@ module Opbeat
     end
 
     def trace signature, kind = nil, parents = nil, extra = {}, &block
-      trace = Trace.new self, signature, kind, [@root.signature], extra
+      trace = Trace.new self, signature, kind, [@root_trace.signature], extra
       traces << trace
       trace.start
 

--- a/lib/opbeat/util.rb
+++ b/lib/opbeat/util.rb
@@ -13,7 +13,7 @@ module Opbeat
       }.freeze
 
       NEWLINE = "\n".freeze
-      SPACE = " ".freeze
+      SPACE = " ".freeze
 
       def initialize config = {}
         @config = DEFAULTS.merge(config)
@@ -27,8 +27,10 @@ module Opbeat
           trace.relative_start
         end
 
+        traces.shift # root
+
         traces = traces.map do |trace|
-          descriptions = [trace.signature || ""]
+          descriptions = ["#{trace.signature} - #{trace.kind}"]
 
           if include_parents
             parents_sig = trace.parents.join(' ')
@@ -37,14 +39,18 @@ module Opbeat
 
           indent = (trace.relative_start * f).to_i
 
-          desc_lengths = descriptions.map { |d| w - d.length }
-          desc_indent = [0, ([indent] + desc_lengths).min].max
+          longest_desc = descriptions.map(&:length).max
+          desc_indent = [indent, w - longest_desc].min
 
           span = (trace.duration * f).to_i
 
-          descriptions.map do |desc|
+          lines = descriptions.map do |desc|
             "#{SPACE * desc_indent}#{desc}"
-          end + ["#{" " * indent}+#{"-" * [(span - 2), 0].max}+"]
+          end
+
+          lines << "#{SPACE * indent}+#{"-" * [(span - 2), 0].max}+"
+
+          lines
         end.join(NEWLINE)
 
         <<-STR.gsub(/^\s{10}/, '')

--- a/lib/opbeat/util.rb
+++ b/lib/opbeat/util.rb
@@ -30,17 +30,17 @@ module Opbeat
         traces.shift # root
 
         traces = traces.map do |trace|
-          descriptions = ["#{trace.signature} - #{trace.kind}"]
+          descriptions = ["#{trace.signature} - #{trace.kind}"[0...w]]
 
           if include_parents
-            parents_sig = trace.parents.join(' ')
+            parents_sig = trace.parents.join(' ')[0...w]
             descriptions << parents_sig
           end
 
           indent = (trace.relative_start * f).to_i
 
           longest_desc = descriptions.map(&:length).max
-          desc_indent = [indent, w - longest_desc].min
+          desc_indent = [[indent, w - longest_desc].min, 0].max
 
           span = (trace.duration * f).to_i
 

--- a/lib/opbeat/worker.rb
+++ b/lib/opbeat/worker.rb
@@ -10,11 +10,10 @@ module Opbeat
       end
     end
 
-    def initialize config, queue
+    def initialize config, queue, http_client
       @config = config
       @queue = queue
-
-      @http_client = HttpClient.new config
+      @http_client = http_client
     end
 
     attr_reader :config

--- a/lib/opbeat/worker.rb
+++ b/lib/opbeat/worker.rb
@@ -1,48 +1,44 @@
-require 'opbeat/data_builders'
-
 module Opbeat
   # @api private
   class Worker
     include Logging
 
-    def initialize config, queue, http_client
+    class PostRequest < Struct.new(:path, :data)
+      # require all parameters
+      def initialize path, data
+        super(path, data)
+      end
+    end
+
+    def initialize config, queue
       @config = config
       @queue = queue
-      @http_client = http_client
 
-      @data_builder = DataBuilders::Transactions.new(config).freeze
+      @http_client = HttpClient.new config
     end
 
     attr_reader :config
 
     def run
       loop do
-        info "Sending pending transactions: #{@queue.length}"
-        send_transactions
-        sleep config.transaction_post_interval
-      end
-
-      at_exit do
-        send_transactions
+        process_queue
       end
     end
 
-    def send_transactions
-      return if @queue.empty?
+    private
 
-      transactions = []
-
-      until @queue.empty?
-        transactions << @queue.shift
+    def process_queue
+      while req = @queue.pop
+        process_request req
       end
+    end
 
-      info "Post #{transactions.length} transactions"
+    def process_request req
+      debug "Worker processing #{req.path}"
       begin
-        data = @data_builder.build(transactions)
-        # debug { JSON.pretty_generate(data) }
-        @http_client.post('/transactions/', JSON.dump(data))
+        @http_client.post(req.path, req.data)
       rescue => e
-        info "Failed POST #{e.inspect}"
+        fatal "Failed POST: #{e.inspect}"
         debug e.backtrace.join("\n")
       end
     end

--- a/spec/opbeat/client_spec.rb
+++ b/spec/opbeat/client_spec.rb
@@ -169,8 +169,23 @@ module Opbeat
     end
 
     context "with errors disabled" do
+      subject do
+        Opbeat::Client.inst
+      end
+
+      before do
+        config.disable_errors = true
+        Opbeat.start! config
+      end
+      after { Opbeat.stop! }
+
       describe "#report" do
         it "doesn't do anything" do
+          exception = Exception.new('BOOM')
+
+          Client.inst.report exception
+
+          expect(Client.inst.queue.length).to be 0
         end
       end
     end

--- a/spec/opbeat/client_spec.rb
+++ b/spec/opbeat/client_spec.rb
@@ -123,6 +123,14 @@ module Opbeat
           expect(subject.queue.length).to be 1
           expect(subject.queue.pop).to be_a Worker::PostRequest
         end
+
+        it "may send inline" do
+          release = { rev: "abc123", status: 'completed' }
+
+          subject.release release, inline: true
+
+          expect(WebMock).to have_requested(:post, %r{/releases/$}).with(body: release)
+        end
       end
 
     end

--- a/spec/opbeat/configuration_spec.rb
+++ b/spec/opbeat/configuration_spec.rb
@@ -20,5 +20,29 @@ module Opbeat
       expect(conf.timeout).to be 1000
     end
 
+    describe "#validate" do
+      let(:auth_opts) { { app_id: 'x', organization_id: 'y', secret_token: 'z' } }
+      it "doesn't raise when all auth options are set" do
+        expect do
+          Configuration.new(auth_opts).validate!
+        end
+      end
+      it "is true" do
+        expect(Configuration.new(auth_opts).validate!).to be true
+      end
+      it "needs an app_id" do
+        auth_opts.delete(:app_id)
+        expect { Configuration.new(auth_opts).validate! }.to raise_error(Error)
+      end
+      it "needs an organization_id" do
+        auth_opts.delete(:organization_id)
+        expect { Configuration.new(auth_opts).validate! }.to raise_error(Error)
+      end
+      it "needs a secret token" do
+        auth_opts.delete(:secret_token)
+        expect { Configuration.new(auth_opts).validate! }.to raise_error(Error)
+      end
+    end
+
   end
 end

--- a/spec/opbeat/data_builders/transactions_spec.rb
+++ b/spec/opbeat/data_builders/transactions_spec.rb
@@ -26,18 +26,18 @@ module Opbeat
               kind: 'special.kind',
               result: 200,
               timestamp: 694220400,
-              durations: [100.0, 100.0]
+              durations: [100.00002384185791, 100.00002384185791]
             }, {
               transaction: 'endpoint',
               result: 500,
               kind: 'special.kind',
               timestamp: 694220400,
-              durations: [100.0]
+              durations: [100.00002384185791]
             }],
             traces: [{
               transaction: 'endpoint',
               signature: 'endpoint',
-              durations: [[100.0, 100.0], [100.0, 100.0], [100.0, 100.0]],
+              durations: [[100.00002384185791, 100.00002384185791], [100.00002384185791, 100.00002384185791], [100.00002384185791, 100.00002384185791]],
               start_time: 0.0,
               kind: 'transaction',
               timestamp: 694220400,

--- a/spec/opbeat/integration/delayed_job_spec.rb
+++ b/spec/opbeat/integration/delayed_job_spec.rb
@@ -29,7 +29,8 @@ if defined?(Delayed)
       MyJob.new.delay.blow_up exception
 
       expect(Delayed::Worker.new.work_off).to eq [0, 1]
-      expect(Opbeat::Client.inst.queue.length).to be 1
+      # expect(Opbeat::Client.inst.queue.length).to be 1
+      expect(WebMock).to have_requested(:post, %r{/errors/$})
     end
   end
 end

--- a/spec/opbeat/integration/delayed_job_spec.rb
+++ b/spec/opbeat/integration/delayed_job_spec.rb
@@ -29,9 +29,7 @@ if defined?(Delayed)
       MyJob.new.delay.blow_up exception
 
       expect(Delayed::Worker.new.work_off).to eq [0, 1]
-      expect(WebMock).to have_requested(:post, %r{/errors/$}).with({
-        body: /{"message":"Exception: BOOM"/
-      })
+      expect(Opbeat::Client.inst.queue.length).to be 1
     end
   end
 end

--- a/spec/opbeat/integration/rails_spec.rb
+++ b/spec/opbeat/integration/rails_spec.rb
@@ -10,7 +10,8 @@ describe 'Rails integration' do
   def boot
     TinderButForHotDogs.initialize!
     TinderButForHotDogs.routes.draw do
-      resources :users
+      get 'error', to: 'users#error'
+      root to: 'users#index'
     end
   end
 
@@ -31,6 +32,10 @@ describe 'Rails integration' do
     class UsersController < ActionController::Base
       def index
         render text: 'HOT DOGS!'
+      end
+
+      def error
+        raise Exception.new("NO KETCHUP!")
       end
     end
 
@@ -54,13 +59,13 @@ describe 'Rails integration' do
   end
 
   it "adds an exception handler and handles exceptions" do
-    get '/404'
+    get '/error'
 
-    expect(Opbeat::Client.inst.queue.length).to be 1
+    expect(WebMock).to have_requested(:post, %r{/errors/$})
   end
 
   it "traces actions and enqueues transaction" do
-    get '/users'
+    get '/'
 
     expect(Opbeat::Client.inst.pending_transactions.length).to be 1
   end

--- a/spec/opbeat/integration/rails_spec.rb
+++ b/spec/opbeat/integration/rails_spec.rb
@@ -72,10 +72,10 @@ describe 'Rails integration' do
 
   it "logs when failing to report error" do
     allow(Opbeat::Client.inst).to receive(:report).and_raise
-    allow(Rails.logger).to receive(:debug)
+    allow(Rails.logger).to receive(:error)
 
     get '/404'
 
-    expect(Rails.logger).to have_received(:debug).with(/\*\* \[Opbeat\] Error capturing/)
+    expect(Rails.logger).to have_received(:error).with(/\*\* \[Opbeat\] Error capturing/)
   end
 end

--- a/spec/opbeat/integration/rails_spec.rb
+++ b/spec/opbeat/integration/rails_spec.rb
@@ -50,20 +50,19 @@ describe 'Rails integration' do
 
   before :each do
     Opbeat::Client.inst.queue.clear
+    Opbeat::Client.inst.instance_variable_set :@pending_transactions, []
   end
 
   it "adds an exception handler and handles exceptions" do
     get '/404'
 
-    expect(WebMock).to have_requested(:post, %r{/errors/$}).with({
-      body: %r{ActionController::RoutingError.*404}
-    })
+    expect(Opbeat::Client.inst.queue.length).to be 1
   end
 
   it "traces actions and enqueues transaction" do
     get '/users'
 
-    expect(Opbeat::Client.inst.queue.length).to be 1
+    expect(Opbeat::Client.inst.pending_transactions.length).to be 1
   end
 
   it "logs when failing to report error" do

--- a/spec/opbeat/integration/resque_spec.rb
+++ b/spec/opbeat/integration/resque_spec.rb
@@ -36,9 +36,7 @@ if defined? Resque
       job = worker.reserve
       worker.perform job
 
-      expect(WebMock).to have_requested(:post, %r{/errors/$}).with({
-        body: /{"message":"Exception: BOOM"/
-      })
+      expect(Opbeat::Client.inst.queue.length).to be 1
     end
 
   end

--- a/spec/opbeat/integration/sidekiq_spec.rb
+++ b/spec/opbeat/integration/sidekiq_spec.rb
@@ -33,9 +33,7 @@ if defined?(Sidekiq)
         MyWorker.perform_async exception
       end.to raise_error(Exception)
 
-      expect(WebMock).to have_requested(:post, %r{/errors/$}).with({
-        body: /{"message":"RuntimeError: BOOM"/
-      })
+      expect(Opbeat::Client.inst.queue.length).to be 1
     end
 
   end

--- a/spec/opbeat/middleware_spec.rb
+++ b/spec/opbeat/middleware_spec.rb
@@ -8,7 +8,8 @@ module Opbeat
       app = Middleware.new(lambda do |env|
         [200, {}, ['']]
       end)
-      status, _, _ = app.call({})
+      status, _, body = app.call({})
+      body.close
 
       expect(status).to eq 200
       expect(Opbeat::Client.inst.pending_transactions.length).to be 1

--- a/spec/opbeat/middleware_spec.rb
+++ b/spec/opbeat/middleware_spec.rb
@@ -11,7 +11,7 @@ module Opbeat
       status, _, _ = app.call({})
 
       expect(status).to eq 200
-      expect(Opbeat::Client.inst.queue.length).to be 1
+      expect(Opbeat::Client.inst.pending_transactions.length).to be 1
       expect(Opbeat::Client.inst.current_transaction).to be_nil
     end
 
@@ -24,9 +24,7 @@ module Opbeat
       expect(Opbeat::Client.inst.queue.length).to be 1
       expect(Opbeat::Client.inst.current_transaction).to be_nil
 
-      expect(WebMock).to have_requested(:post, %r{/errors/$}).with({
-        body: /{"message":"Exception: BOOM"/
-      })
+      expect(Opbeat::Client.inst.queue.length).to be 1
     end
 
   end

--- a/spec/opbeat/trace_spec.rb
+++ b/spec/opbeat/trace_spec.rb
@@ -31,7 +31,7 @@ module Opbeat
         travel 0.1
         trace.done
 
-        expect(trace.duration).to eq 100.0
+        expect(trace.duration.round 4).to eq 100.0
         expect(trace).to be_done
       end
     end

--- a/spec/opbeat/transaction_spec.rb
+++ b/spec/opbeat/transaction_spec.rb
@@ -31,7 +31,7 @@ module Opbeat
 
         expect(transaction.result).to be 200
         expect(transaction.traces.first).to be_done
-        expect(transaction.duration).to be 100.0
+        expect(transaction.duration.round 4).to be 100.0
       end
     end
 
@@ -69,13 +69,13 @@ module Opbeat
         expect(subject.traces.last.parents).to eq [subject.traces.first.signature]
       end
       it "has a duration" do
-        expect(subject.traces.last.duration).to eq 100.0
+        expect(subject.traces.last.duration.round 4).to eq 100.0
       end
       it "has a relative start" do
         expect(subject.traces.last.relative_start.round 2).to eq 100.0
       end
       it "has a total duration" do
-        expect(subject.duration).to eq 200.0
+        expect(subject.duration.round 4).to eq 200.0
       end
     end
 

--- a/spec/opbeat/transaction_spec.rb
+++ b/spec/opbeat/transaction_spec.rb
@@ -37,7 +37,7 @@ module Opbeat
 
     describe "#submit" do
       it "ends transaction and submits it to the client" do
-        client = double('client', enqueue: true, :current_transaction= => true)
+        client = double('client', submit_transaction: true, :current_transaction= => true)
         transaction = Transaction.new client, 'Test'
 
         travel 0.1
@@ -46,7 +46,7 @@ module Opbeat
         expect(transaction.result).to be 200
         expect(transaction).to be_done
         expect(client).to have_received(:current_transaction=)
-        expect(client).to have_received(:enqueue).with transaction
+        expect(client).to have_received(:submit_transaction).with transaction
       end
     end
 

--- a/spec/opbeat/util_spec.rb
+++ b/spec/opbeat/util_spec.rb
@@ -26,8 +26,9 @@ module Opbeat
       expect(subject.split("\n").map(&:length).find { |l| l < 100 })
     end
 
-    it "is beautiful" do
-      puts subject
-    end
+    # preview
+    # it "is beautiful" do
+    #   puts subject
+    # end
   end
 end

--- a/spec/opbeat/util_spec.rb
+++ b/spec/opbeat/util_spec.rb
@@ -15,7 +15,7 @@ module Opbeat
       end
     end
     subject do
-      Util::Inspector.new.transaction(transaction)
+      Util::Inspector.new.transaction(transaction, include_parents: true)
     end
 
     it "doesn't explode" do

--- a/spec/opbeat/util_spec.rb
+++ b/spec/opbeat/util_spec.rb
@@ -6,9 +6,9 @@ module Opbeat
     let(:transaction) do
       Opbeat.transaction 'Test' do |transaction|
         travel 0.1
-        Opbeat.trace('test 1') { travel 0.1 }
+        Opbeat.trace('test 1', 'trace.test') { travel 0.1 }
         travel 0.1
-        Opbeat.trace('test 2') { travel 0.15 }
+        Opbeat.trace('test 2', 'trace.test') { travel 0.15 }
         travel 0.1
 
         transaction
@@ -26,8 +26,8 @@ module Opbeat
       expect(subject.split("\n").map(&:length).find { |l| l < 100 })
     end
 
-    # it "is beautiful" do
-    #   puts subject
-    # end
+    it "is beautiful" do
+      puts subject
+    end
   end
 end

--- a/spec/opbeat/worker_spec.rb
+++ b/spec/opbeat/worker_spec.rb
@@ -7,7 +7,7 @@ module Opbeat
     let :worker do
       config = Configuration.new
       @queue = Queue.new
-      Worker.new config, @queue, HttpClient.new(config)
+      Worker.new config, @queue
     end
 
     describe "#run" do

--- a/spec/opbeat/worker_spec.rb
+++ b/spec/opbeat/worker_spec.rb
@@ -3,11 +3,10 @@ require 'spec_helper'
 module Opbeat
   RSpec.describe Worker do
 
-
     let :worker do
       config = Configuration.new
       @queue = Queue.new
-      Worker.new config, @queue
+      Worker.new config, @queue, HttpClient.new(config)
     end
 
     describe "#run" do

--- a/spec/opbeat_spec.rb
+++ b/spec/opbeat_spec.rb
@@ -4,17 +4,28 @@ RSpec.describe Opbeat do
 
   it { should_not be_started }
 
+  describe "self.start!" do
+    it "delegates to client" do
+      conf = Opbeat::Configuration.new app_id: 'x', organization_id: 'y', secret_token: 'z'
+      expect(Opbeat::Client).to receive(:start!).with(conf) { true }
+      Opbeat.start! conf
+    end
+    it "validates configuration" do
+      conf = Opbeat::Configuration.new
+      expect { Opbeat.start! conf }.to raise_error(Opbeat::Error)
+    end
+  end
+
+  it { should delegate :stop!, to: Opbeat }
+
   describe "when Opbeat is started", start: true do
-    it { should delegate :start!, to: Opbeat }
-    it { should delegate :stop!, to: Opbeat }
+    it { should be_started }
 
     it { should delegate :transaction, to: Opbeat::Client.inst, args: ['Test', nil, nil] }
     it { should delegate :trace, to: Opbeat::Client.inst, args: ['test', nil, nil, {}] }
     it { should delegate :report, to: Opbeat::Client.inst, args: [Exception.new, nil] }
-    it { should delegate :release, to: Opbeat::Client.inst, args: [{}] }
+    it { should delegate :release, to: Opbeat::Client.inst, args: [{}, {}] }
     it { should delegate :capture, to: Opbeat::Client.inst }
-
-    it { should be_started }
   end
 
 end

--- a/spec/opbeat_spec.rb
+++ b/spec/opbeat_spec.rb
@@ -12,6 +12,7 @@ RSpec.describe Opbeat do
     it { should delegate :trace, to: Opbeat::Client.inst, args: ['test', nil, nil, {}] }
     it { should delegate :report, to: Opbeat::Client.inst, args: [Exception.new, nil] }
     it { should delegate :release, to: Opbeat::Client.inst, args: [{}] }
+    it { should delegate :capture, to: Opbeat::Client.inst }
 
     it { should be_started }
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -36,7 +36,11 @@ RSpec.configure do |config|
   end
 
   config.around :each, start: true do |example|
-    config = Opbeat::Configuration.new
+    config = Opbeat::Configuration.new(
+      app_id: 'x',
+      organization_id: 'y',
+      secret_token: 'z'
+    )
     Opbeat.start! config
     example.call
     Opbeat.stop!


### PR DESCRIPTION
This simplifies the worker to only concentrate on sending POST requests. The client in responsible for holding onto `Transactions` until `config.transaction_post_interval` has gone by.

Every message to Opbeat is pushed to a combined queue and sent off asynchronously.