### PR TITLE
Increase timeout and log if it fails, JRuby never sends messages

### DIFF
--- a/lib/opbeat/client.rb
+++ b/lib/opbeat/client.rb
@@ -252,7 +252,9 @@ module Opbeat
     def kill_worker
       return unless worker_running?
       @queue << Worker::StopMessage.new
-      @worker_thread.join 1
+      unless @worker_thread.join 5
+        error "Failed to wait for worker, not all messages sent"
+      end
       @worker_thread = nil
     end
 


### PR DESCRIPTION
When trying to run Opbeat under JRuby, errors that appear close to the process death will not be sent to Opbeat which is unfortunate.

After increasing the timeout this doesn't happen in our setup, and if it happens again it will at least log something and not just silently do the wrong thing.