### PR TITLE
Ensure that the worker is running when we are reporting

### DIFF
--- a/lib/opbeat/client.rb
+++ b/lib/opbeat/client.rb
@@ -173,6 +173,8 @@ module Opbeat
       return if config.disable_errors
       return unless exception
 
+      ensure_worker_running
+
       unless exception.backtrace
         exception.set_backtrace caller
       end


### PR DESCRIPTION
`Opbeat.capture` fails silently unless there's a transaction right now.