### PR TITLE
Allow reporting 'extra' values

### DIFF
--- a/lib/opbeat/error_message.rb
+++ b/lib/opbeat/error_message.rb
@@ -65,6 +65,10 @@ module Opbeat
         error_message.user = User.from_rack_env config, env
       end
 
+      if extra = opts[:extra]
+        error_message.extra = extra
+      end
+
       error_message
     end
   end

--- a/spec/opbeat/error_message_spec.rb
+++ b/spec/opbeat/error_message_spec.rb
@@ -71,6 +71,12 @@ module Opbeat
           expect(error.user).to be_a(ErrorMessage::User)
           expect(error.user.id).to be 1
         end
+
+        it "adds extra data to message" do
+          error = ErrorMessage.from_exception config, real_exception, extra: { "test" => 1 }
+
+          expect(error.extra).to eq("test" => 1)
+        end
       end
     end
 


### PR DESCRIPTION
Allows you to report extra values that shows up in Opbeat.

Example usage (if one also add local variable info to all Exceptions :smile:)

```ruby
Kernel.at_exit do
  Opbeat.report($!, extra: $!.local_variables) if $!
end
```