### PR TITLE
Fix stack frame order

### DIFF
--- a/lib/opbeat/error_message.rb
+++ b/lib/opbeat/error_message.rb
@@ -55,7 +55,7 @@ module Opbeat
       end
 
       if frames = error_message.stacktrace && error_message.stacktrace.frames
-        if first_frame = frames[0]
+        if first_frame = frames.last
           error_message.culprit = "#{first_frame.filename}:#{first_frame.lineno}:in `#{first_frame.function}'"
         end
       end

--- a/lib/opbeat/error_message/stacktrace.rb
+++ b/lib/opbeat/error_message/stacktrace.rb
@@ -11,7 +11,7 @@ module Opbeat
       def self.from config, exception
         return unless exception.backtrace
 
-        new(config, exception.backtrace.map do |line|
+        new(config, exception.backtrace.reverse.map do |line|
           Frame.from_line config, line
         end)
       end

--- a/spec/opbeat/error_message/stacktrace_spec.rb
+++ b/spec/opbeat/error_message/stacktrace_spec.rb
@@ -18,7 +18,7 @@ module Opbeat
         expect(stacktrace.frames).to_not be_empty
 
         # so meta
-        last_frame = stacktrace.frames.first
+        last_frame = stacktrace.frames.last
         expect(last_frame.filename).to eq "opbeat/error_message/stacktrace_spec.rb"
         expect(last_frame.lineno).to be 7
         expect(last_frame.abs_path).to_not be_nil


### PR DESCRIPTION
This fixes #16, which makes sure stack frames are in the right order in the Opbeat interface. After this fix it looks like http://i.imgur.com/OfkLECj.png