### PR TITLE
Make sure SqlSummarizer always returns something

### DIFF
--- a/lib/opbeat/sql_summarizer.rb
+++ b/lib/opbeat/sql_summarizer.rb
@@ -17,11 +17,13 @@ module Opbeat
     def signature_for sql
       return CACHE[sql] if CACHE[sql]
 
-      REGEXES.find do |regex, sig|
+      result = REGEXES.find do |regex, sig|
         if match = sql.match(regex)
           break sig + match[1]
         end
       end
+
+      result || "SQL"
     end
   end
 end

--- a/spec/opbeat/sql_summarizer_spec.rb
+++ b/spec/opbeat/sql_summarizer_spec.rb
@@ -2,5 +2,32 @@ require 'spec_helper'
 
 module Opbeat
   RSpec.describe SqlSummarizer do
+    let(:config) { Configuration.new }
+
+    subject { SqlSummarizer.new(config) }
+
+    it 'summarizes selects' do
+      expect(subject.signature_for("SELECT CAST(SERVERPROPERTY('ProductVersion') AS varchar)")).to eq('SQL')
+    end
+
+    it 'summarizes selects from table' do
+      expect(subject.signature_for("SELECT * FROM table")).to eq('SELECT FROM table')
+    end
+
+    it 'summarizes selects from table with columns' do
+      expect(subject.signature_for("SELECT a, b FROM table")).to eq('SELECT FROM table')
+    end
+
+    it 'summarizes inserts' do
+      expect(subject.signature_for("INSERT INTO table (a, b) VALUES ('A','B')")).to eq('INSERT INTO table')
+    end
+
+    it 'summarizes updates' do
+      expect(subject.signature_for("UPDATE table SET a = 'B' WHERE b = 'B'")).to eq('UPDATE table')
+    end
+
+    it 'summarizes deletes' do
+      expect(subject.signature_for("DELETE FROM table WHERE b = 'B'")).to eq('DELETE FROM table')
+    end
   end
 end


### PR DESCRIPTION
Hello,

I'm not sure what the best solution is to this problem, but the tracing system stops working when we do the following SQL query via Sequel `SELECT CAST(SERVERPROPERTY('ProductVersion') AS varchar)` (returns the version of MS SQL Server)

The issue is that the 'signature' of the SQL cannot be found, so the identifier of the trace ends up as nil, which the API for good reasons doesn't like. But I'm not sure what is the best solution to this, I have first proposal in here. I will add specs when I know what the expected behavior is.

The error message from the API is as following

```F, [2016-02-25T13:29:23.130000 #9720] FATAL -- : ** [Opbeat] Failed POST: #<Opbeat::Error: Error from Opbeat server (400): {
    "error_message": "Unable to validate data.",
    "status": 400,
    "structured_error": {
        "traces": "must be object"
    }
}>```