### PR TITLE
Allow a configurable worker quit timeout

### DIFF
--- a/lib/opbeat/client.rb
+++ b/lib/opbeat/client.rb
@@ -260,7 +260,7 @@ module Opbeat
     def kill_worker
       return unless worker_running?
       @queue << Worker::StopMessage.new
-      unless @worker_thread.join 5
+      unless @worker_thread.join(config.worker_quit_timeout)
         error "Failed to wait for worker, not all messages sent"
       end
       @worker_thread = nil

--- a/lib/opbeat/configuration.rb
+++ b/lib/opbeat/configuration.rb
@@ -16,6 +16,7 @@ module Opbeat
       current_user_method: :current_user,
       environment: ENV['RACK_ENV'] || ENV['RAILS_ENV'] || 'default',
       transaction_post_interval: 60,
+      worker_quit_timeout: 5,
 
       disable_performance: false,
       disable_errors: false,
@@ -43,6 +44,7 @@ module Opbeat
     attr_accessor :current_user_method
     attr_accessor :environment
     attr_accessor :transaction_post_interval
+    attr_accessor :worker_quit_timeout
 
     attr_accessor :disable_performance
     attr_accessor :disable_errors


### PR DESCRIPTION
This allows one of our overloaded servers to always push out a transaction or error. It sometimes needs more than 5 seconds to do it in some workers for some reason and we're losing reports.