### PR TITLE
Adds context blocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,14 @@ class DashboardController < ApplicationController
 end
 ```
 
+or by specifying it as a block using `Opbeat.context` eg:
+
+```ruby
+Opbeat.with_context(user_id: @user.id) do
+  UserMailer.welcome_email(@user).deliver_now
+end
+```
+
 ## Background processing
 
 Opbeat automatically catches exceptions in [delayed_job](https://github.com/collectiveidea/delayed_job) or [sidekiq](http://sidekiq.org/).

--- a/lib/opbeat.rb
+++ b/lib/opbeat.rb
@@ -86,6 +86,19 @@ module Opbeat
     client.set_context context
   end
 
+  # Updates context for errors within the block
+  #
+  # @param context [Hash]
+  # @yield [Trace] Block in which the context is used
+  def self.with_context context, &block
+    unless client
+      return yield if block_given?
+      return nil
+    end
+
+    client.context context, &block
+  end
+
   # Send an exception to Opbeat
   #
   # @param exception [Exception]

--- a/lib/opbeat/client.rb
+++ b/lib/opbeat/client.rb
@@ -173,6 +173,16 @@ module Opbeat
       @context = context
     end
 
+    def with_context context, &block
+      current = @context
+
+      set_context((current || {}).merge(context))
+
+      yield if block_given?
+    ensure
+      set_context(current)
+    end
+
     def report exception, opts = {}
       return if config.disable_errors
       return unless exception


### PR DESCRIPTION
Setting context with a block would be very useful, not sure if `Opbeat.context` is the right name though.

```ruby
Opbeat.context(user_id: @user.id) do
  UserMailer.welcome_email(@user).deliver_now
end
``` 