### PR TITLE
ErrorMessage.from_exception may return nil

### DIFF
--- a/lib/opbeat/client.rb
+++ b/lib/opbeat/client.rb
@@ -183,10 +183,11 @@ module Opbeat
         exception.set_backtrace caller
       end
 
-      error_message = ErrorMessage.from_exception(config, exception, opts)
-      error_message.add_extra(@context) if @context
-      data = @data_builders.error_message.build error_message
-      enqueue Worker::PostRequest.new('/errors/', data)
+      if error_message = ErrorMessage.from_exception(config, exception, opts)
+        error_message.add_extra(@context) if @context
+        data = @data_builders.error_message.build error_message
+        enqueue Worker::PostRequest.new('/errors/', data)
+      end
     end
 
     def report_message message, opts = {}


### PR DESCRIPTION
if the exception is among the excluded exceptions.