### PR TITLE
Rails 5 compatibility: Replaced alias_method_chain

### DIFF
--- a/lib/opbeat.rb
+++ b/lib/opbeat.rb
@@ -96,7 +96,7 @@ module Opbeat
       return nil
     end
 
-    client.context context, &block
+    client.with_context context, &block
   end
 
   # Send an exception to Opbeat

--- a/lib/opbeat/client.rb
+++ b/lib/opbeat/client.rb
@@ -193,10 +193,11 @@ module Opbeat
         exception.set_backtrace caller
       end
 
-      error_message = ErrorMessage.from_exception(config, exception, opts)
-      error_message.add_extra(@context) if @context
-      data = @data_builders.error_message.build error_message
-      enqueue Worker::PostRequest.new('/errors/', data)
+      if error_message = ErrorMessage.from_exception(config, exception, opts)
+        error_message.add_extra(@context) if @context
+        data = @data_builders.error_message.build error_message
+        enqueue Worker::PostRequest.new('/errors/', data)
+      end
     end
 
     def report_message message, opts = {}

--- a/lib/opbeat/integration/rails/inject_exceptions_catcher.rb
+++ b/lib/opbeat/integration/rails/inject_exceptions_catcher.rb
@@ -3,7 +3,8 @@ module Opbeat
     module Rails
       module InjectExceptionsCatcher
         def self.included(cls)
-          cls.send(:alias_method_chain, :render_exception, :opbeat)
+          cls.send(:alias_method, :render_exception_without_opbeat, :render_exception)
+          cls.send(:alias_method, :render_exception, :render_exception_with_opbeat)
         end
 
         def render_exception_with_opbeat(env, exception)


### PR DESCRIPTION
with two calls to alias_method
We could've used Module#prepend, but then we'd have a dependency on Ruby 2.2+