### PR TITLE
Check if `Rails` responds to `application` before calling it

### DIFF
--- a/lib/opbeat/filter.rb
+++ b/lib/opbeat/filter.rb
@@ -62,7 +62,7 @@ module Opbeat
     end
 
     def rails_filters
-      if defined?(::Rails) && Rails.application
+      if defined?(::Rails) && Rails.respond_to?(:application) && Rails.application
         if filters = ::Rails.application.config.filter_parameters
           filters.any? ? filters : nil
         end


### PR DESCRIPTION
When running ActionMailer without Rails, the module `Rails` is defined, but doesn't respond to `application` which means that the whole thing topples over when running Opbeat and nothing ends up on Opbeat about it.

This fixes that issue.