### PR TITLE
Add a default for view_paths

### DIFF
--- a/lib/opbeat/configuration.rb
+++ b/lib/opbeat/configuration.rb
@@ -23,6 +23,8 @@ module Opbeat
 
       debug_traces: false,
 
+      view_paths: [],
+
       # for tests
       disable_worker: false
     }.freeze


### PR DESCRIPTION
By default view_paths is nil, which means that if you run Opbeat with default settings, it crashes in `action_view.rb:22` which made me :'c since I couldn't see the actual stacktrace and instead get a `NoMethodError: undefined method 'find' for nil:NilClass` and a stack trace like

```
relative_path at …workers/gems/jruby/2.2.0/bundler/gems/opbeat-ruby-688734cf8584/lib/opbeat/normalizers/action_view.rb:22
path_for at …workers/gems/jruby/2.2.0/bundler/gems/opbeat-ruby-688734cf8584/lib/opbeat/normalizers/action_view.rb:18
normalize_render at …workers/gems/jruby/2.2.0/bundler/gems/opbeat-ruby-688734cf8584/lib/opbeat/normalizers/action_view.rb:7
…
```

With this change I get the right error and stacktrace. \o/