### PR TITLE
Style: Avoid overriding Kernel#p

### DIFF
--- a/lib/opbeat/injections.rb
+++ b/lib/opbeat/injections.rb
@@ -37,8 +37,8 @@ module Opbeat
     end
 
     def self.register_require_hook registration
-      registration.require_paths.each do |p|
-        require_hooks[p] = registration
+      registration.require_paths.each do |path|
+        require_hooks[path] = registration
       end
     end
 
@@ -49,8 +49,8 @@ module Opbeat
         installed[registration.const_name] = registration
         registration.install
 
-        registration.require_paths.each do |p|
-          require_hooks.delete p
+        registration.require_paths.each do |path|
+          require_hooks.delete path
         end
       end
     end

--- a/lib/opbeat/normalizers/action_view.rb
+++ b/lib/opbeat/normalizers/action_view.rb
@@ -19,11 +19,11 @@ module Opbeat
         end
 
         def relative_path path
-          root = config.view_paths.find { |p| path.start_with? p }
+          root = config.view_paths.find { |vp| path.start_with? vp }
           type = :app
 
           unless root
-            root = Gem.path.find { |p| path.start_with? p }
+            root = Gem.path.find { |gp| path.start_with? gp }
             type = :gem
           end
 


### PR DESCRIPTION
Tiny change: [Kernel#p](http://ruby-doc.org/core-2.3.1/Kernel.html#method-i-p) is never overridden, even for a short while.