### PR TITLE
Ensure worker is running in report_message

### DIFF
--- a/lib/opbeat/client.rb
+++ b/lib/opbeat/client.rb
@@ -202,6 +202,8 @@ module Opbeat
     def report_message message, opts = {}
       return if config.disable_errors
 
+      ensure_worker_running
+
       error_message = ErrorMessage.new(config, message, opts)
       error_message.add_extra(@context) if @context
       data = @data_builders.error_message.build error_message


### PR DESCRIPTION
Errors reported with 'report_message' are only sent to Opbeat if the worker is already running. The message is queued correctly but is only sent when the worker is started. This happens if another error is reported using e.g. 'capture'.