### PR TITLE
README: before_action is current Rails [ci skip]

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ You may specify extra context for errors ahead of time by using `Opbeat.set_cont
 
 ```ruby
 class DashboardController < ApplicationController
-  before_filter do
+  before_action do
     Opbeat.set_context(timezone: current_user.timezone)
   end
 end


### PR DESCRIPTION
This PR changes the README example about Rails controllers to use `before_action`, which is the current way of saying `before_filter`.