### PR TITLE
README: Bump version in "Installation" [ci skip]

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 Add the following to your `Gemfile`:
 
 ```ruby
-gem 'opbeat', '~> 3.0.8'
+gem 'opbeat', '~> 3.0.9'
 ```
 
 The Opbeat gem adheres to [Semantic


### PR DESCRIPTION
This trivial PR keeps the README up to date by adding the latest published gem version.