### PR TITLE
README typo in example for with_context [ci skip]

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ class DashboardController < ApplicationController
 end
 ```
 
-or by specifying it as a block using `Opbeat.context` eg:
+or by specifying it as a block using `Opbeat.with_context` eg:
 
 ```ruby
 Opbeat.with_context(user_id: @user.id) do


### PR DESCRIPTION
This PR uses the same invocation when mentioning the feature as in the example that comes after.