### PR TITLE
Gemfiles use HTTPS

### DIFF
--- a/gemfiles/Gemfile.rails-5.0.x
+++ b/gemfiles/Gemfile.rails-5.0.x
@@ -1,4 +1,4 @@
 eval_gemfile File.expand_path('../Gemfile.base', __FILE__)
 
 gem 'rails', '~> 5.0.0'
-gem 'sinatra', github: 'sinatra'
+gem 'sinatra', git: 'https://github.com/sinatra/sinatra.git'

--- a/gemfiles/Gemfile.rails-HEAD
+++ b/gemfiles/Gemfile.rails-HEAD
@@ -1,7 +1,7 @@
 eval_gemfile File.expand_path('../Gemfile.base', __FILE__)
 
-gem 'rack', github: 'rack/rack', branch: 'master'
-gem 'arel', github: 'rails/arel', branch: 'master'
-gem 'rails', github: 'rails/rails', branch: 'master'
-gem 'sinatra', github: 'sinatra'
+gem 'rack', git: 'https://github.com/rack/rack.git'
+gem 'arel', git: 'https://github.com/rails/arel.git'
+gem 'rails', git: 'https://github.com/rails/rails.git'
+gem 'sinatra', git: 'https://github.com/sinatra/sinatra.git'
 


### PR DESCRIPTION
This PR changes the additional Gemfiles' gem lines to use git-with-HTTPS instead of the simpler-but-warning-generating `github:` annotation.