### PR TITLE
Make Sinatra work with config.disable_performance

### DIFF
--- a/lib/opbeat/injections/sinatra.rb
+++ b/lib/opbeat/injections/sinatra.rb
@@ -9,8 +9,9 @@ module Opbeat
 
             def dispatch!(*args, &block)
               dispatch_without_opb!(*args, &block).tap do
-                if route = env['sinatra.route']
-                  Opbeat.transaction(nil).endpoint = route
+                transaction = Opbeat.transaction(nil)
+                if route = env['sinatra.route'] and transaction
+                  transaction.endpoint = route
                 end
               end
             end

--- a/spec/opbeat/integration/sinatra_spec.rb
+++ b/spec/opbeat/integration/sinatra_spec.rb
@@ -63,4 +63,45 @@ module Opbeat
     end
 
   end
+
+
+  RSpec.describe "sinatra integration without perfomance" do
+    include Rack::Test::Methods
+
+    def config
+      @config ||= Opbeat::Configuration.new do |c|
+        c.app_id = 'X'
+        c.organization_id = 'Y'
+        c.secret_token = 'Z'
+        c.disable_worker = true
+        c.disable_performance = true
+      end
+    end
+
+    around do |example|
+      Opbeat.start! config
+      example.call
+      Opbeat.stop!
+    end
+
+    class TestApp < ::Sinatra::Base
+      disable :show_exceptions
+      use Opbeat::Middleware
+
+      get '/' do
+        erb "I am an inline template!"
+      end
+    end
+
+    def app
+      TestApp
+    end
+
+    it "wraps routes in transactions" do
+      get '/'
+      expect(Opbeat::Client.inst.pending_transactions.last).to be_nil
+    end
+
+  end
+
 end


### PR DESCRIPTION
There is a bug in the Sinatra injection when the client is configured with ``disable_performance``.

This results in the error:

```
NoMethodError:
       undefined method `endpoint=' for nil:NilClass
     # ./lib/opbeat/injections/sinatra.rb:13:in `block in dispatch!'
     # ./lib/opbeat/injections/sinatra.rb:11:in `tap'
     # ./lib/opbeat/injections/sinatra.rb:11:in `dispatch!'
     # ./lib/opbeat/middleware.rb:10:in `call'
     # ./lib/opbeat/middleware.rb:10:in `call'
     # ./spec/opbeat/integration/sinatra_spec.rb:101:in `block (2 levels) in <module:Opbeat>'
     # ./spec/opbeat/integration/sinatra_spec.rb:83:in `block (2 levels) in <module:Opbeat>'
```

This happens because the Sinatra injector deals with ``Opbeat.transaction(nil)`` which is ``nil`` when ``disable_performance`` is set to true.

My solution was to check if this the transaction is not nil: https://github.com/sanity-io/opbeat-ruby/blob/98c57ab3bf3111d30233dcda3020c22ec102b2b6/lib/opbeat/injections/sinatra.rb#L13 before setting the endpoint.

Not sure if this is the most graceful way of solving the problem, but at least we can use Opbeat in Sinatra now without performance tracking.

PS: I have also included an own sinatra injector spec with ``disable_performance`` set to true.