### PR TITLE
Error message: include word Opbeat

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,8 @@ rvm:
   - 2.0.0
   - 2.1.6
   - 2.2.3
-  - 2.3.1
+  - 2.3.3
+  - 2.4.0
 gemfile:
   - gemfiles/Gemfile.rails-3.2.x
   - gemfiles/Gemfile.rails-4.0.x
@@ -16,7 +17,7 @@ gemfile:
   - gemfiles/Gemfile.rails-5.0.x
 matrix:
   include:
-    - rvm: 2.3.1
+    - rvm: 2.3.3
       gemfile: gemfiles/Gemfile.rails-HEAD
 
   exclude:
@@ -24,6 +25,14 @@ matrix:
       gemfile: gemfiles/Gemfile.rails-5.0.x
     - rvm: 2.1.6
       gemfile: gemfiles/Gemfile.rails-5.0.x
+    - rvm: 2.4.0
+      gemfile: gemfiles/Gemfile.rails-3.2.x
+    - rvm: 2.4.0
+      gemfile: gemfiles/Gemfile.rails-4.0.x
+    - rvm: 2.4.0
+      gemfile: gemfiles/Gemfile.rails-4.1.x
+    - rvm: 2.4.0
+      gemfile: gemfiles/Gemfile.rails-4.2.x
 
 notifications:
   email: false

--- a/gemfiles/Gemfile.rails-4.2.x
+++ b/gemfiles/Gemfile.rails-4.2.x
@@ -1,4 +1,5 @@
 eval_gemfile File.expand_path('../Gemfile.base', __FILE__)
 
 gem 'rails', '~> 4.2.0'
+gem 'nokogiri', '< 1.7'
 gem 'sinatra'

--- a/lib/opbeat/configuration.rb
+++ b/lib/opbeat/configuration.rb
@@ -69,7 +69,7 @@ module Opbeat
 
     def validate!
       %w{app_id secret_token organization_id}.each do |key|
-        raise Error.new("Configuration missing `#{key}'") unless self.send(key)
+        raise Error.new("Opbeat Configuration missing `#{key}'") unless self.send(key)
       end
 
       true


### PR DESCRIPTION
On failing to configure Opbeat, the message is quite bare.

This PR adds the word _Opbeat_ to the failure message.

This will help a confused log reader trying to find what broke.