### PR TITLE
Fix sanitizing data bug.

### DIFF
--- a/lib/opbeat/error_message.rb
+++ b/lib/opbeat/error_message.rb
@@ -29,6 +29,7 @@ module Opbeat
     attr_reader :config
     attr_accessor :message
     attr_reader :timestamp
+    attr_reader :filter
     attr_accessor :level
     attr_accessor :logger
     attr_accessor :culprit
@@ -61,7 +62,7 @@ module Opbeat
       end
 
       if env = opts[:rack_env]
-        error_message.http = HTTP.from_rack_env env, filter: @filter
+        error_message.http = HTTP.from_rack_env env, filter: error_message.filter
         error_message.user = User.from_rack_env config, env
       end
 

--- a/lib/opbeat/filter.rb
+++ b/lib/opbeat/filter.rb
@@ -39,13 +39,7 @@ module Opbeat
     end
 
     def sanitize key, value
-      return value unless value.is_a?(String)
-
-      if should_filter?(key)
-        return MASK
-      end
-
-      value
+      should_filter?(key) ? MASK : value
     end
 
     private
@@ -53,7 +47,7 @@ module Opbeat
     def should_filter? key
       @params.any? do |param|
         case param
-        when String
+        when String, Symbol
           key.to_s == param.to_s
         when Regexp
           param.match(key)

--- a/spec/opbeat/configuration_spec.rb
+++ b/spec/opbeat/configuration_spec.rb
@@ -6,6 +6,13 @@ module Opbeat
     it "has defaults" do
       conf = Configuration.new
       expect(conf.timeout).to be 100
+      expect(conf.filter_parameters).to eq [/(authorization|password|passwd|secret)/i]
+    end
+
+    it "overwrites defaults when config given" do
+      conf = Configuration.new(filter_parameters: [:secret])
+      expect(conf.timeout).to be 100
+      expect(conf.filter_parameters).to eq [:secret]
     end
 
     it "can initialize with a hash" do

--- a/spec/opbeat/error_message_spec.rb
+++ b/spec/opbeat/error_message_spec.rb
@@ -56,6 +56,12 @@ module Opbeat
           expect(error.http.url).to eq 'http://example.org/'
         end
 
+        it "uses proper filter options" do
+          env = Rack::MockRequest.env_for '/nested/path?foo=bar&password=SECRET'
+          error = ErrorMessage.from_exception config, real_exception, rack_env: env
+          expect(error.http.query_string).to eq "foo=bar&password=[FILTERED]"
+        end
+
         class DummyController
           def current_user
             Struct.new(:id, :email, :username).new(1, 'john@example.com', 'leroy')

--- a/spec/opbeat/filter_spec.rb
+++ b/spec/opbeat/filter_spec.rb
@@ -2,7 +2,9 @@ require 'spec_helper'
 
 module Opbeat
   RSpec.describe Filter do
-    let(:config) { Configuration.new filter_parameters: [/password/, 'passwd'] }
+    let(:config) do 
+      Configuration.new filter_parameters: [/password/, 'pwd', :_secret, :int_secret, 'non_existing']
+    end
 
     subject do
       Filter.new config
@@ -10,13 +12,19 @@ module Opbeat
 
     describe "#apply" do
       it "filters a string" do
-        filtered = subject.apply "password=SECRET&foo=bar"
-        expect(filtered).to eq 'password=[FILTERED]&foo=bar'
+        data = "password=SECRET&foo=bar&_secret=abc&pwd=de1&int_secret=123"
+        filtered_data = "password=[FILTERED]&foo=bar&_secret=[FILTERED]&pwd=[FILTERED]&int_secret=[FILTERED]"
+        expect(subject.apply data).to eq filtered_data
       end
 
       it "filters a hash" do
-        filtered = subject.apply({ passwd: 'SECRET' })
-        expect(filtered).to eq({ passwd: '[FILTERED]' })
+        data = { password: 'SECRET', foo: :bar, _secret: 'abc', pwd: 'de1', int_secret: 123 }
+        filtered_data = { password: '[FILTERED]', 
+                          foo: :bar, 
+                          _secret: '[FILTERED]', 
+                          pwd: '[FILTERED]', 
+                          int_secret: '[FILTERED]'}
+        expect(subject.apply data).to eq filtered_data
       end
     end
   end


### PR DESCRIPTION
* Filter Params were not working when set as symbols.
* Filter was not applied properly in http error_messages.
* Filter was only applied to String values.

This should fix [Issue#39](https://github.com/opbeat/opbeat-ruby/issues/39)