### PR TITLE
Fix `Opbeat.with_context`

### DIFF
--- a/lib/opbeat.rb
+++ b/lib/opbeat.rb
@@ -96,7 +96,7 @@ module Opbeat
       return nil
     end
 
-    client.context context, &block
+    client.with_context context, &block
   end
 
   # Send an exception to Opbeat

--- a/spec/opbeat_spec.rb
+++ b/spec/opbeat_spec.rb
@@ -21,6 +21,7 @@ RSpec.describe Opbeat do
     it { should delegate :trace, to: Opbeat::Client.inst, args: ['test', nil, {}] }
     it { should delegate :report, to: Opbeat::Client.inst, args: [Exception.new, nil] }
     it { should delegate :set_context, to: Opbeat::Client.inst, args: [{}] }
+    it { should delegate :with_context, to: Opbeat::Client.inst, args: [{}] }
     it { should delegate :report_message, to: Opbeat::Client.inst, args: ["My message", nil] }
     it { should delegate :release, to: Opbeat::Client.inst, args: [{}, {}] }
     it { should delegate :capture, to: Opbeat::Client.inst }


### PR DESCRIPTION
Calling `Opbeat.with_context` results in a `NoMethodError: undefined method 'context' for #<Opbeat::Client:0x007f8ee2fb4528>`.